### PR TITLE
Add dumb-init as entrypoint to remove chrome zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV KANGOOROO_VERSION=v2.0.1.stable14
 USER root
 
 RUN apt update -y && \
-    apt install -y wget default-jre unzip ffmpeg
+    apt install -y wget default-jre unzip ffmpeg dumb-init
 
 
 # Find out what is the latest version of the chromedriver & chome from chrome-for-testing available
@@ -50,3 +50,7 @@ RUN sed -i -e "s/\$SERVICE_TAG/$version/g" service_manifest.yml
 
 # Switch to assemblyline user
 USER assemblyline
+
+# using dumb-init as entrypoint to remove zombie chrome processes
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["python", "/etc/process_handler.py"]


### PR DESCRIPTION
When opening and closing Chrome in a docker container, it doesn't terminate all of its child processes properly, so there are a lot of zombie processes that are left when we run kangooroo. 
![image](https://github.com/user-attachments/assets/585cc9e9-1d6f-4038-ae13-19f30dee4bef)

https://stackoverflow.com/questions/75599266/use-chromedriver-quit-and-cloesd-why-have-zombie-chrome-process


I am using https://github.com/Yelp/dumb-init that create a process on PID 1, which prevents orphan processes to get re-parented to that PID and not get terminated.

 