### PR TITLE
update Kangooroo version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG branch=latest
 FROM cccs/assemblyline-v4-service-base:$branch
 
 ENV SERVICE_PATH=urldownloader.urldownloader.URLDownloader
-ENV KANGOOROO_VERSION=v2.0.1.stable19
+ENV KANGOOROO_VERSION=v2.0.1.stable20
 # latest version of chrome that we tested
 ENV CHROME_VERSION=135.0.7049.114
 


### PR DESCRIPTION
Update to use newest Kangooroo version.
The newest version has an updated patch that removes the misleading error message `ERROR com.browserup.bup.BrowserUpProxyServer - The requested URL is not valid.` 

